### PR TITLE
🐛 Bug fix: `setError` does not work properly under certain circumstances

### DIFF
--- a/example/src/components/demo.vue
+++ b/example/src/components/demo.vue
@@ -45,16 +45,20 @@ function mySubmit() {
       <p class="text-red !mb-0 !mt-1 text-sm">{{ status.age.message || '&nbsp;' }}</p>
     </label>
     <div space-x-3 mt-1>
-      <button class="text-sm btn" type="submit">
+      <button text-sm btn type="submit">
         Submit
       </button>
 
-      <button class="text-sm btn" type="button" @click="clearErrors">
+      <button text-sm btn type="button" @click="clearErrors">
         Clear Errors
       </button>
 
-      <button class="text-sm btn" type="button" @click="reset">
+      <button text-sm btn type="button" @click="reset">
         Reset
+      </button>
+
+      <button text-sm btn bg-red hover="bg-red-600" type="button" @click="status.age.setError('Manual error!', true)">
+        Set Error
       </button>
     </div>
   </form>

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ function initStatus<FormT extends {}>(
         return
 
       // monitor changes
-      stopEffect = watchEffect(verify)
+      stopEffect = watchEffect(ruleEffect)
     }
 
     function setError(message: string, isError = true) {
@@ -155,7 +155,7 @@ function initStatus<FormT extends {}>(
       setError('', false)
     }
 
-    function verify() {
+    function ruleEffect() {
       const fri: RuleItem | RuleItem[] = (formRule as any)?.[key]
       if (!fri)
         return true
@@ -177,6 +177,10 @@ function initStatus<FormT extends {}>(
           setError('', false)
         }
       }
+    }
+
+    function verify() {
+      ruleEffect()
       return !status[key].isError
     }
   }


### PR DESCRIPTION
When the input result is correct, the changes generated by calling `setError` are overwritten by the `watchEffect` that is subsequently triggered