### PR TITLE
feat: add option to switch to full verification

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -447,6 +447,37 @@ describe('useForm', () => {
     expect(wrapper.rule.age.validate('abc', { fullResult: true })).toStrictEqual({ valid: false, message: 'expect numbers' })
     expect(wrapper.rule.age.validate('abc', { fullResult: false })).toEqual(false)
   })
+
+  it('should verify all fields when fullValidation is true', async () => {
+    const wrapper = useSetup(() => {
+      const { form, status, verify } = useForm({
+        form: () => ({
+          name: '',
+          age: '',
+          email: '',
+        }),
+        rule: {
+          name: val => !!val || 'name required',
+          age: val => !!val || 'age required',
+          email: val => !!val || 'email required',
+        },
+        fullValidation: true,
+      })
+      return { form, status, verify }
+    })
+
+    wrapper.verify()
+    await nextTick()
+
+    expect(wrapper.status.name.isError).true
+    expect(wrapper.status.age.isError).true
+    expect(wrapper.status.email.isError).true
+    expect(wrapper.status.name.message).toBe('name required')
+    expect(wrapper.status.age.message).toBe('age required')
+    expect(wrapper.status.email.message).toBe('email required')
+
+    wrapper.unmount()
+  })
 })
 
 describe('object type field', () => {

--- a/src/type/form.ts
+++ b/src/type/form.ts
@@ -26,6 +26,11 @@ export interface UseFormParam<FormT> {
    * @default false
    */
   lazy?: UseFormLazy
+  /**
+   * Verify all rules even if some rules fail
+   * @default false
+   */
+  fullValidation?: boolean
 }
 
 export interface ValidateOptions<FullResult extends boolean> { fullResult?: FullResult }

--- a/src/type/form.ts
+++ b/src/type/form.ts
@@ -27,7 +27,8 @@ export interface UseFormParam<FormT> {
    */
   lazy?: UseFormLazy
   /**
-   * Verify all rules even if some rules fail
+   * If `true`, all rules will be fully validated.
+   *
    * @default false
    */
   fullValidation?: boolean


### PR DESCRIPTION
~~This PR fixes #53 where form validation stops prematurely due to short-circuit evaluation in the `verify()` method. Previously, when a field validation failed, subsequent fields would not be validated due to the `&&` operator's short-circuit behavior.~~

This PR will add an option to switch to full verification.